### PR TITLE
Argument must be an array warning

### DIFF
--- a/phperror-gui.php
+++ b/phperror-gui.php
@@ -23,11 +23,11 @@ $cache     = null;
 /**
  * @var array Array of log lines
  */
-$logs = array();
+$logs = [];
 /**
  * @var array Array of log types
  */
-$types = array();
+$types = [];
 
 /**
  * https://gist.github.com/amnuts/8633684

--- a/phperror-gui.php
+++ b/phperror-gui.php
@@ -20,6 +20,14 @@ $error_log = null;
  * @var string|null Path to log cache - must be writable - null for no cache
  */
 $cache     = null;
+/**
+ * @var array Array of log lines
+ */
+$logs = array();
+/**
+ * @var array Array of log types
+ */
+$types = array();
 
 /**
  * https://gist.github.com/amnuts/8633684


### PR DESCRIPTION
If no error log file can be found some warnings are raised.
- fix ksort() argument warning
- fix uasort() argument warning
